### PR TITLE
[FEAT] allow Persistence to accept a redis_connection option to use an existing redis connection

### DIFF
--- a/lib/linnaeus/persistence.rb
+++ b/lib/linnaeus/persistence.rb
@@ -18,17 +18,21 @@ class Linnaeus::Persistence < Linnaeus
 
     @scope = options[:scope]
 
-    @redis = Redis.new(
-      host: options[:redis_host],
-      port: options[:redis_port],
-      db: options[:redis_db],
-      scheme: options[:redis_scheme],
-      path: options[:redis_path],
-      timeout: options[:redis_timeout],
-      password: options[:redis_password],
-      id: options[:redis_id],
-      tcp_keepalive: options[:redis_tcp_keepalive]
-    )
+    if options[:redis_connection]
+      @redis = options[:redis_connection]
+    else
+      @redis = Redis.new(
+        host: options[:redis_host],
+        port: options[:redis_port],
+        db: options[:redis_db],
+        scheme: options[:redis_scheme],
+        path: options[:redis_path],
+        timeout: options[:redis_timeout],
+        password: options[:redis_password],
+        id: options[:redis_id],
+        tcp_keepalive: options[:redis_tcp_keepalive]
+      )
+    end
 
     self
   end

--- a/spec/linnaeus_persistence_spec.rb
+++ b/spec/linnaeus_persistence_spec.rb
@@ -6,6 +6,11 @@ describe Linnaeus::Persistence do
     lp.clear_training_data
   end
 
+  it "should accept an existing redis connection" do
+    lp = Linnaeus::Persistence.new(redis_connection: Redis.new)
+    lp.redis.should_not be_nil
+  end
+
   it 'sets keys properly with defaults' do
     lp2 = get_linnaeus_persistence
     train_a_document_in('foobar')


### PR DESCRIPTION
Allowing Linnaeus / Persistence to accept an existing redis connection instead of setting up a new one.

``` ruby
$redis = Redis.new
Linnaeus.new(redis_connection: $redis)
```
