### PR TITLE
Soften Redis dependency to ~> 3.0

### DIFF
--- a/linnaeus.gemspec
+++ b/linnaeus.gemspec
@@ -52,7 +52,7 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<redis>, ["~> 3.0.0"])
+      s.add_runtime_dependency(%q<redis>, ["~> 3.0"])
       s.add_runtime_dependency(%q<stemmer>, ["~> 1.0.0"])
       s.add_development_dependency(%q<rspec>, ["~> 2.11.0"])
       s.add_development_dependency(%q<yard>, ["~> 0.7"])
@@ -62,7 +62,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<simplecov>, [">= 0"])
       s.add_development_dependency(%q<redcarpet>, [">= 0"])
     else
-      s.add_dependency(%q<redis>, ["~> 3.0.0"])
+      s.add_dependency(%q<redis>, ["~> 3.0"])
       s.add_dependency(%q<stemmer>, ["~> 1.0.0"])
       s.add_dependency(%q<rspec>, ["~> 2.11.0"])
       s.add_dependency(%q<yard>, ["~> 0.7"])
@@ -73,7 +73,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<redcarpet>, [">= 0"])
     end
   else
-    s.add_dependency(%q<redis>, ["~> 3.0.0"])
+    s.add_dependency(%q<redis>, ["~> 3.0"])
     s.add_dependency(%q<stemmer>, ["~> 1.0.0"])
     s.add_dependency(%q<rspec>, ["~> 2.11.0"])
     s.add_dependency(%q<yard>, ["~> 0.7"])


### PR DESCRIPTION
Hello :wave: , could we soften the dependency of Redis:

```
Bundler could not find compatible versions for gem "redis":
  In Gemfile:
    sidekiq-unique-jobs (= 3.0.14) ruby depends on
      sidekiq (>= 2.6) ruby depends on
        redis (>= 3.2.1, ~> 3.2) ruby

    sidekiq-unique-jobs (= 3.0.14) ruby depends on
      sidekiq (>= 2.6) ruby depends on
        redis-namespace (>= 1.5.2, ~> 1.5) ruby depends on
          redis (>= 3.0.4, ~> 3.0) ruby

    linnaeus (>= 0) ruby depends on
      redis (~> 3.0.0) ruby

    redis (>= 0) ruby
```

and

```
Bundler could not find compatible versions for gem "redis":
  In Gemfile:
    sidekiq (>= 0) ruby depends on
      redis (>= 3.2.1, ~> 3.2) ruby

    sidekiq (>= 0) ruby depends on
      redis-namespace (>= 1.5.2, ~> 1.5) ruby depends on
        redis (>= 3.0.4, ~> 3.0) ruby

    linnaeus (>= 0) ruby depends on
      redis (~> 3.0.0) ruby

    redis (>= 0) ruby
```

Thank you! :heart: 
